### PR TITLE
Feat/33 (이호연) useApi 훅스

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -101,3 +101,20 @@ export const API_PATH = {
       ITEM_DETAIL: (id: string) => `/rental/${id}`,
    },
 };
+
+/**
+ * @description API query string
+ */
+export const QUERY_STRING = {
+   PAGE: 'page',
+   SIZE: 'size',
+   SORT: 'sort',
+   KEYWORD: 'keyword',
+};
+
+/**
+ * @description Page Size
+ */
+export const PAGE_SIZE = {
+   RENTAL: 20,
+};

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,44 @@
+import axios, { AxiosResponse } from 'axios';
+import { CONSTANTS } from 'constant';
+import { useAlert } from './useAlert';
+
+// axios.interceptors.request.use((config) => {
+//    if (config.auth) {
+//       const token = localStorage.getItem(CONSTANTS.atk_key);
+//       if (token) {
+//          config.headers.Authorization = `Bearer ${token}`;
+//       }
+//    }
+//    return config;
+// });
+
+interface Options {
+   authenticate?: boolean;
+   log?: boolean;
+}
+
+const client = axios.create({
+   baseURL: CONSTANTS.SERVER_URL,
+});
+
+export const useApi = () => {
+   const { alert } = useAlert();
+
+   const get = async <T>(url: string, options?: Options): Promise<T> => {
+      const token = localStorage.getItem(CONSTANTS.atk_key);
+      try {
+         const { data } = await client.get<AxiosResponse<T>>(url, {
+            headers: {
+               Authorization: options?.authenticate && token ? `Bearer ${token}` : null,
+            },
+         });
+         options?.log && console.log(data);
+         return data.data;
+      } catch (error) {
+         alert(error);
+         return Promise.reject(error);
+      }
+   };
+
+   return { get };
+};

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,20 +1,11 @@
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import { CONSTANTS } from 'constant';
 import { useAlert } from './useAlert';
-
-// axios.interceptors.request.use((config) => {
-//    if (config.auth) {
-//       const token = localStorage.getItem(CONSTANTS.atk_key);
-//       if (token) {
-//          config.headers.Authorization = `Bearer ${token}`;
-//       }
-//    }
-//    return config;
-// });
 
 interface Options {
    authenticate?: boolean;
    log?: boolean;
+   id?: string;
 }
 
 const client = axios.create({
@@ -23,22 +14,113 @@ const client = axios.create({
 
 export const useApi = () => {
    const { alert } = useAlert();
+   const token = localStorage.getItem(CONSTANTS.atk_key);
 
+   /**
+    * 특정 URL로 GET 요청을 보내고 응답 데이터를 반환합니다.
+    *
+    * @template T - 응답 데이터의 타입입니다.
+    * @param {string} url - GET 요청을 보낼 URL입니다. CONSTANTS.SERVER_URL을 기준으로 상대 경로를 작성합니다.
+    * @param {Options} [options] - GET 요청에 대한 옵션입니다.
+    * @param {boolean} [options.authenticate] - 토큰을 헤더에 담아 보낼지 여부입니다.
+    * @param {boolean} [options.log] - 응답 데이터를 콘솔에 출력할지 여부입니다.
+    * @returns {Promise<T>} - 응답 데이터를 담은 Promise 객체입니다.
+    * @throws {Error} - 요청이 실패한 경우 에러를 던집니다.
+    * @author 이호연
+    */
    const get = async <T>(url: string, options?: Options): Promise<T> => {
-      const token = localStorage.getItem(CONSTANTS.atk_key);
       try {
-         const { data } = await client.get<AxiosResponse<T>>(url, {
+         const { data } = await client.get<T>(url, {
             headers: {
                Authorization: options?.authenticate && token ? `Bearer ${token}` : null,
             },
+            params: {
+               id: options?.id,
+            },
          });
          options?.log && console.log(data);
-         return data.data;
+         return data;
       } catch (error) {
          alert(error);
          return Promise.reject(error);
       }
    };
 
-   return { get };
+   /**
+    * 특정 URL로 POST 요청을 보내고 응답 데이터를 반환합니다.
+    *
+    * @template Req - 요청 데이터의 타입입니다.
+    * @template Res - 응답 데이터의 타입입니다.
+    * @param {string} url - POST 요청을 보낼 URL입니다. CONSTANTS.SERVER_URL을 기준으로 상대 경로를 작성합니다.
+    * @param {Req} body - POST 요청에 담아 보낼 데이터입니다.
+    * @param options - POST 요청에 대한 옵션입니다.
+    * @param {boolean} [options.authenticate] - 토큰을 헤더에 담아 보낼지 여부입니다.
+    * @param {boolean} [options.log] - 응답 데이터를 콘솔에 출력할지 여부입니다.
+    * @returns {Promise<Res>} - 응답 데이터를 담은 Promise 객체입니다.
+    * @throws {Error} - 요청이 실패한 경우 에러를 던집니다.
+    * @author 이호연
+    */
+   const post = async <Req, Res = unknown>(url: string, body: Req, options?: Options): Promise<Res> => {
+      try {
+         const { data } = await client.post<Res>(url, body, {
+            headers: {
+               Authorization: options?.authenticate && token ? `Bearer ${token}` : null,
+            },
+         });
+         options?.log && console.log(data);
+         return data;
+      } catch (error) {
+         alert(error);
+         return Promise.reject(error);
+      }
+   };
+
+   /**
+    * 특정 URL로 PATCH 요청을 보내고 응답 데이터를 반환합니다.
+    *
+    * @template Req - 요청 데이터의 타입입니다.
+    * @template Res - 응답 데이터의 타입입니다.
+    * @param {string} url - PATCH 요청을 보낼 URL입니다. CONSTANTS.SERVER_URL을 기준으로 상대 경로를 작성합니다.
+    * @param {Req} body - PATCH 요청에 담아 보낼 데이터입니다.
+    * @param options - PATCH 요청에 대한 옵션입니다.
+    * @param {boolean} [options.authenticate] - 토큰을 헤더에 담아 보낼지 여부입니다.
+    * @param {boolean} [options.log] - 응답 데이터를 콘솔에 출력할지 여부입니다.
+    * @returns {Promise<Res>} - 응답 데이터를 담은 Promise 객체입니다.
+    * @throws {Error} - 요청이 실패한 경우 에러를 던집니다.
+    * @author 이호연
+    */
+   const patch = async <Req, Res = unknown>(url: string, body: Req, options?: Options): Promise<Res> => {
+      try {
+         const { data } = await client.patch<Res>(url, body, {
+            headers: {
+               Authorization: options?.authenticate && token ? `Bearer ${token}` : null,
+            },
+         });
+         options?.log && console.log(data);
+         return data;
+      } catch (error) {
+         alert(error);
+         return Promise.reject(error);
+      }
+   };
+
+   return {
+      get,
+      post,
+      patch,
+      async delete(url: string, options?: Options) {
+         try {
+            const { data } = await client.delete(url, {
+               headers: {
+                  Authorization: options?.authenticate && token ? `Bearer ${token}` : null,
+               },
+            });
+            options?.log && console.log(data);
+            return data;
+         } catch (error) {
+            alert(error);
+            return Promise.reject(error);
+         }
+      },
+   };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import axios from 'axios';
 import './index.css';
-import { CONSTANTS } from './constant';
-
-axios.defaults.baseURL = CONSTANTS.SERVER_URL;
-
-axios.interceptors.request.use((config) => {
-   const token = localStorage.getItem(CONSTANTS.atk_key);
-   if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-   }
-   return config;
-});
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<App />);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import axios from 'axios';
 import { API_PATH } from 'constant';
-import { useAlert } from 'hooks/useAlert';
 import { useEffectOnce } from 'hooks/useEffectOnce';
 import { Banner, Notice, Petition } from 'components/main';
 import type { IBanner } from 'components/main/banner';
 import type { INotice } from 'components/main/notice';
 import type { IPetition } from 'components/main/petition';
+import { useApi } from 'hooks/useApi';
 
 interface IMain {
    carousels: IBanner[];
@@ -21,16 +20,12 @@ interface IMain {
 }
 
 export default function Main() {
-   const { alert } = useAlert();
    const [main, setMain] = useState<IMain | null>(null);
+   const { get } = useApi();
 
    const fetchMain = async () => {
-      try {
-         const { data } = await axios.get<IMain>(API_PATH.MAIN.ROOT);
-         setMain(data);
-      } catch (e) {
-         if (axios.isAxiosError<unknown>(e)) alert(e);
-      }
+      const data = await get<IMain>(API_PATH.MAIN.ROOT);
+      setMain(data);
    };
 
    useEffectOnce(() => {

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import axios from 'axios';
 import { API_PATH } from 'constant';
-import { useAlert } from 'hooks/useAlert';
 import { useEffectOnce } from 'hooks/useEffectOnce';
 import Box from 'components/ui/box';
 import Button from 'components/ui/button';
 import Text from 'components/ui/text';
 import { useLayout } from 'hooks/useLayout';
+import { useApi } from 'hooks/useApi';
 
 interface IMyInfo {
    studentId: string;
@@ -23,17 +22,13 @@ interface IMyInfo {
 }
 
 export default function MyPage() {
-   const { alert } = useAlert();
    const { setTitle } = useLayout();
    const [myInfo, setMyInfo] = React.useState<IMyInfo | null>(null);
+   const { get } = useApi();
 
    const fetchMyInfo = async () => {
-      try {
-         const { data } = await axios.get<IMyInfo>(API_PATH.USER.ME);
-         setMyInfo(data);
-      } catch (error) {
-         alert(error);
-      }
+      const data = await get<IMyInfo>(API_PATH.USER.ME, { authenticate: true });
+      setMyInfo(data);
    };
 
    useEffectOnce(() => {

--- a/src/pages/rental/index.tsx
+++ b/src/pages/rental/index.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import axios from 'axios';
 import Board from 'components/common/board';
-import { API_PATH, ROUTES } from 'constant';
-import { useAlert } from 'hooks/useAlert';
+import { API_PATH, PAGE_SIZE, QUERY_STRING, ROUTES } from 'constant';
 import { useEffectOnce } from 'hooks/useEffectOnce';
 import { ReactComponent as ChevronRight } from 'assets/images/chevron_right.svg';
 import SpeedDial from 'components/ui/speed-dial';
 import { Link } from 'react-router-dom';
 import { useLayout } from 'hooks/useLayout';
 import { IPaging } from 'api/axios-interface';
+import { useApi } from 'hooks/useApi';
 
 interface Content {
    id: number;
@@ -18,16 +17,14 @@ interface Content {
 
 export default function Rental() {
    const [rental, setRental] = React.useState<IPaging<Content> | null>(null);
-   const { alert } = useAlert();
    const { setTitle } = useLayout();
+   const { get } = useApi();
 
    const fetchRental = async () => {
-      try {
-         const { data } = await axios.get<IPaging<Content>>(API_PATH.RENTAL.ITEM + '?page=0&size=20');
-         setRental(data);
-      } catch (error) {
-         alert(error);
-      }
+      const data = await get<IPaging<Content>>(
+         API_PATH.RENTAL.ITEM + `?${QUERY_STRING.PAGE}=0&${QUERY_STRING.SIZE}=${PAGE_SIZE.RENTAL}`,
+      );
+      setRental(data);
    };
 
    useEffectOnce(() => {


### PR DESCRIPTION
**What is this PR?**
- api를 쉽게 사용하기 위한 `useApi()` 훅 추가

**What has changed?**
<img width="1704" alt="스크린샷 2023-10-11 12 43 19" src="https://github.com/EveryUniv/next-student-council-frontend/assets/84632077/d3bb3c26-05c9-4a4d-9421-cecd266ebab5">
1. get, patch, put, delete 등의 메소드 추가
2. client를 axios로 적용하여 `{ data }` 구조분해 할당 하지 않아도 됩니다.
3. option 적용
   i. `authenticate`: 토큰을 담아서 보낼지 여부를 지정합니다.
   ii. `log`: 데이터를 콘솔에 찍습니다.
   iii. `id`: get 등 메소드에서 param의 id를 지정합니다.
4. error handling을 hooks에서 처리 해 줍니다.

closes #33 
